### PR TITLE
chore: Удаление `assignees` и `reviewers` в конфигурации Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "assignees": [
-    "@Iskait"
-  ],
   "extends": [
     "github>Pacific-Agency/renovate-config"
-  ],
-  "reviewers": [
-    "@Iskait"
   ]
 }


### PR DESCRIPTION
Сейчас reviewer выставляется автоматически из команды фронтенда, поэтому дополнительно выставлять его через Renovate не нужно. Мержить будет тот, на кого выпало ревью.