### PR TITLE
refactor: Переработка ссылки на карту через `URL`

### DIFF
--- a/src/runtime/components/UtilsMapWidget.vue
+++ b/src/runtime/components/UtilsMapWidget.vue
@@ -1,10 +1,34 @@
 <script setup lang="ts">
-defineProps<{
+import { watch } from "vue"
+
+const props = defineProps<{
   /** Локализация виджета */
   locale?: string
   /** `ID` виджета Яндекс.Карт */
   widgetId: string | undefined
 }>()
+
+/** Ссылка на карту */
+const mapURL = new URL("https://yandex.ru/map-widget/v1/-/" + props.widgetId)
+
+watch(
+  [props],
+  () => {
+    // Если передана локализация
+    if (props.locale) {
+      // Выставляем параметр lang
+      mapURL.searchParams.set("lang", props.locale)
+    } else {
+      mapURL.searchParams.delete("lang")
+    }
+  },
+  {
+    immediate: true,
+  }
+)
+
+// Выставляем параметр z
+mapURL.searchParams.append("z", "16")
 </script>
 
 <template>
@@ -12,9 +36,7 @@ defineProps<{
     allowfullscreen="true"
     class="map-widget"
     height="100%"
-    :src="`https://yandex.ru/map-widget/v1/-/${widgetId}${
-      locale ? `?lang=${locale}` : ''
-    }${locale ? '&' : '?'}z=100`"
+    :src="mapURL.href"
     width="100%"
   ></iframe>
 </template>

--- a/tests/components/UtilsMapWidget.spec.ts
+++ b/tests/components/UtilsMapWidget.spec.ts
@@ -29,7 +29,7 @@ describe.sequential("Компонент UtilsMapWidget", () => {
 
     // Ожидается правильный src карты
     expect(widgetURL.href).toBe(
-      `https://yandex.ru/map-widget/v1/-/${widgetId}?z=100`
+      `https://yandex.ru/map-widget/v1/-/${widgetId}?z=16`
     )
   })
 
@@ -41,7 +41,7 @@ describe.sequential("Компонент UtilsMapWidget", () => {
     expect(widgetClassList).toContain(classList)
   })
 
-  test("Выставляется параметр z равный 100", async () => {
+  test("Выставляется параметр z равный 16", async () => {
     /** Получение src карты */
     const widgetURL = new URL(wrapper.get("iframe").attributes("src") ?? "")
 
@@ -49,7 +49,7 @@ describe.sequential("Компонент UtilsMapWidget", () => {
     const searchParams = widgetURL.searchParams
 
     // Ожидается правильный параметр z
-    expect(searchParams.get("z")).toBe("100")
+    expect(searchParams.get("z")).toBe("16")
   })
 
   test("Добавляется параметр `lang` в ссылку при передаче локализации", async () => {
@@ -67,6 +67,36 @@ describe.sequential("Компонент UtilsMapWidget", () => {
     expect(searchParams.get("lang")).toBe("en")
   })
 
+  test("Изменение параметра `lang`", async () => {
+    await wrapper.setProps({
+      locale: "ru",
+    })
+
+    /** Получение src карты */
+    const widgetURL = new URL(wrapper.get("iframe").attributes("src") ?? "")
+
+    /** Параметры URL */
+    const searchParams = widgetURL.searchParams
+
+    // Ожидается правильный параметр lang
+    expect(searchParams.get("lang")).toBe("ru")
+  })
+
+  test("Удаление параметра `lang`", async () => {
+    await wrapper.setProps({
+      locale: undefined,
+    })
+
+    /** Получение src карты */
+    const widgetURL = new URL(wrapper.get("iframe").attributes("src") ?? "")
+
+    /** Параметры URL */
+    const searchParams = widgetURL.searchParams
+
+    // Ожидается правильный параметр lang
+    expect(searchParams.get("lang")).toBeNull()
+  })
+
   test("Параметр z правильно взаимодействует с lang", async () => {
     await wrapper.setProps({
       locale: "en",
@@ -79,6 +109,6 @@ describe.sequential("Компонент UtilsMapWidget", () => {
     const searchParams = widgetURL.searchParams
 
     // Ожидается правильные параметры
-    expect(searchParams.toString()).toMatchInlineSnapshot(`"lang=en&z=100"`)
+    expect(searchParams.toString()).toMatchInlineSnapshot(`"z=16&lang=en"`)
   })
 })


### PR DESCRIPTION
### 📝 Описание изменений
Ссылка теперь работает через `URL`, что позволит в дальнейшем проще добавлять для нее параметры.