### PR TITLE
fix: Удаление `headers` из генерируемого ключа `usePagination`

### DIFF
--- a/src/runtime/composables/usePagination.ts
+++ b/src/runtime/composables/usePagination.ts
@@ -100,9 +100,13 @@ export default async function <TResponse>(
    */
   const params = defu(options, defaults)
 
+  // Создаем объект для ключа, удалив из параметров хедеры
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { headers, ...paramsWithoutHeaders } = params
+
   // Выставляем ключ состоящий из параметров
   params.key = hash({
-    params,
+    paramsWithoutHeaders,
     url,
   })
 


### PR DESCRIPTION
### 📎 Связанная задача
DEVDES-1004

### 📝 Описание изменений
Сейчас на сайте Олимпа в списке врачей и услуг необходимо в запрос передавать хедеры авторизации, так как с помощью этого реализована система черновиков.

Для передачи клиентского хедера на SSR рендер используется функция `useRequestHeaders()`, и в серверном запросе её значение используется для генерации ключа.

При этом на клиенте эта функция возвращает `undefined`, так как хедеры и так передаются в запрос. Но из-за этого получается, что ключ запроса на клиенте генерируется с другими данными, то есть на клиенте ключ запроса получается другой.

Из-за этого, после клиентского запроса все результаты пропадают, так как клиент пытается найти серверный запрос с несуществующим ключом.

Для решения этой проблемы я удаляю все хедеры при генерации ключа запроса, он генерируется из остальных параметров.